### PR TITLE
Spotify token middleware

### DIFF
--- a/internal/jwt/jwt.go
+++ b/internal/jwt/jwt.go
@@ -11,6 +11,12 @@ import (
 	"github.com/ranktify/ranktify-be/internal/model"
 )
 
+type AccessTokenClaims struct {
+	UserID   uint64
+	Username string
+	Email    string
+}
+
 func getAccessKey() []byte {
 	accesskey := os.Getenv("JWT_ACCESS_KEY")
 	if accesskey == "" {
@@ -34,7 +40,9 @@ func getIssuerString() string {
 
 type customClaims struct {
 	jwt.RegisteredClaims
-	UserID float64 `json:"user_id"`
+	UserID   float64 `json:"user_id"`
+	Username string  `json:"username,omitempty"` // missing in the rt but not in the at
+	Email    string  `json:"email,omitempty"`
 }
 
 // validate a token using the provided secret key, assumes that the signing method was HS256.
@@ -166,4 +174,17 @@ func ParseRefreshTokenClaims(tokenString string) (*model.JWTRefreshToken, error)
 	}
 
 	return rt, nil
+}
+
+func GetClaimsFromAccessToken(token *jwt.Token) (*AccessTokenClaims, error) {
+	claims, ok := token.Claims.(*customClaims)
+	if !ok {
+		return nil, fmt.Errorf("error extracting claims from token 1")
+	}
+
+	return &AccessTokenClaims{
+		UserID:   uint64(claims.UserID),
+		Username: claims.Username,
+		Email:    claims.Email,
+	}, nil
 }

--- a/internal/middleware/spotifyTokenMiddleware.go
+++ b/internal/middleware/spotifyTokenMiddleware.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func SpotifyTokenMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rawSpotifyToken := c.GetHeader("Spotify-Token")
+		if rawSpotifyToken == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Spotify-Token header is required"})
+			return
+		}
+		accessToken := strings.TrimPrefix(rawSpotifyToken, "Bearer ")
+		if accessToken == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "Spotify-Token header is required"})
+			return
+		}
+
+		c.Set("spotifyToken", accessToken)
+		c.Next()
+	}
+}

--- a/internal/route/api.go
+++ b/internal/route/api.go
@@ -19,12 +19,14 @@ func ApiRoutes(router *gin.RouterGroup, db *sql.DB) {
 		api.POST("/refresh", tokensHandler.Refresh)
 
 		// protected routes
-		// Spotify
+		// Spotify auth
 		api.Use(middleware.AuthMiddleware())
-		api.Use(middleware.SpotifyTokenMiddleware())
-		api.GET("/rank", spotifyHandler.GetSongsToRank)
 		api.POST("/callback", spotifyHandler.AuthCallback)
 		api.POST("/spotify-refresh", spotifyHandler.RefreshAccessToken)
+
+		// spotify routes that need a access token
+		api.Use(middleware.SpotifyTokenMiddleware())
+		api.GET("/rank", spotifyHandler.GetSongsToRank)
 
 	}
 }

--- a/internal/route/api.go
+++ b/internal/route/api.go
@@ -21,6 +21,7 @@ func ApiRoutes(router *gin.RouterGroup, db *sql.DB) {
 		// protected routes
 		// Spotify
 		api.Use(middleware.AuthMiddleware())
+		api.Use(middleware.SpotifyTokenMiddleware())
 		api.GET("/rank", spotifyHandler.GetSongsToRank)
 		api.POST("/callback", spotifyHandler.AuthCallback)
 		api.POST("/spotify-refresh", spotifyHandler.RefreshAccessToken)


### PR DESCRIPTION
AuthMiddleware now adds the access jwt claims into the request context. Created an extra function to parse the claims and return the claims in a struct to the middleware. 

Created another middleware that adds the spotify token in the `Spotify-Token` header to the request context, also validates that the token is present before it reaches a handler.

Closes #26 