### PR TITLE
Frontend request, top tracks ranked weekly, among friends and song discovery by genre

### DIFF
--- a/internal/dao/rankings.go
+++ b/internal/dao/rankings.go
@@ -1,7 +1,9 @@
 package dao
 
 import (
+	"context"
 	"database/sql"
+	"time"
 
 	"github.com/ranktify/ranktify-be/internal/model"
 )
@@ -33,7 +35,7 @@ func (dao *RankingsDao) GetRankedSongs(userID uint64) ([]model.Rankings, error) 
 			&ranking.RankingID,
 			&ranking.SongID,
 			&ranking.Rank,
-		); err != nil{
+		); err != nil {
 			return nil, err
 		}
 		rankings = append(rankings, ranking)
@@ -42,4 +44,79 @@ func (dao *RankingsDao) GetRankedSongs(userID uint64) ([]model.Rankings, error) 
 		return nil, err
 	}
 	return rankings, nil
+}
+
+func (dao *RankingsDao) GetTopWeeklyRankedSongs(ctx context.Context) ([]model.Song, error) {
+	query := `
+		-- get all the rank songs and their average rank and rating 
+		WITH RankedSongs AS (
+			SELECT
+				song_id,
+				AVG(rank) AS avg_rank,
+				COUNT(*)  AS ratings_count
+			FROM rankings
+			WHERE 
+				updated_at >= $1 AND updated_at < $2
+			GROUP BY song_id
+			ORDER BY
+				avg_rank DESC,      -- higher average rank is better
+				ratings_count DESC -- Higher rating count breaks ties (more popular)
+			LIMIT 5
+		)
+		SELECT
+			s.song_id,
+			s.spotify_id,
+			s.title,
+			s.artist,
+			s.album,  -- Select other song details you need
+			s.genre,  -- Select other song details you need
+			s.cover_uri,
+			s.preview_uri
+		FROM songs s
+		JOIN RankedSongs rs ON s.song_id = rs.song_id
+		ORDER BY
+			rs.avg_rank DESC,      
+			rs.ratings_count DESC;
+	`
+	now := time.Now()
+	// today at midnight
+	todayMid := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+	// compute how many days since Monday:
+	// (Weekday()+6)%7 maps Monday→0, Tuesday→1, … Sunday→6
+	offset := (int(now.Weekday()) + 6) % 7
+
+	// this week’s Monday 00:00
+	startThisWeek := todayMid.AddDate(0, 0, -offset)
+
+	// last week’s Monday 00:00
+	startLastWeek := startThisWeek.AddDate(0, 0, -7)
+
+	rows, err := dao.DB.QueryContext(ctx, query, startLastWeek, startThisWeek)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var songs []model.Song
+	for rows.Next() {
+		var song model.Song
+		if err := rows.Scan(
+			&song.SongID,
+			&song.SpotifyID,
+			&song.Title,
+			&song.Artist,
+			&song.Album,
+			&song.Genre,
+			&song.CoverURI,
+			&song.PreviewURI,
+		); err != nil {
+			return nil, err
+		}
+		songs = append(songs, song)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return songs, nil
 }

--- a/internal/dao/rankings.go
+++ b/internal/dao/rankings.go
@@ -104,8 +104,9 @@ func (dao *RankingsDao) GetTopWeeklyRankedSongs(ctx context.Context) ([]model.So
 			s.spotify_id,
 			s.title,
 			s.artist,
-			s.album,  -- Select other song details you need
-			s.genre,  -- Select other song details you need
+			s.album,  
+			s.release_date,
+			s.genre,  
 			s.cover_uri,
 			s.preview_uri
 		FROM songs s
@@ -143,6 +144,7 @@ func (dao *RankingsDao) GetTopWeeklyRankedSongs(ctx context.Context) ([]model.So
 			&song.Title,
 			&song.Artist,
 			&song.Album,
+			&song.ReleaseDate,
 			&song.Genre,
 			&song.CoverURI,
 			&song.PreviewURI,

--- a/internal/handler/friends.go
+++ b/internal/handler/friends.go
@@ -166,3 +166,24 @@ func (h *FriendHandler) DeleteFriendRequest(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "Friend request canceled successfully"})
 }
+
+func (h *FriendHandler) GetTop5TracksAmongFriends(c *gin.Context) {
+	userIDAny, ok := c.Get("userId")
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDAny.(uint64)
+
+	topTracks, err := h.DAO.GetTopNTracksAmongFriends(c.Request.Context(), userID, 5)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve top tracks among friends"})
+		return
+	}
+	if topTracks == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "No top tracks found among friends"})
+		return
+	}
+
+	c.JSON(http.StatusOK, topTracks)
+}

--- a/internal/handler/rankings.go
+++ b/internal/handler/rankings.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"database/sql"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -50,9 +51,13 @@ func (h *RankingsHandler) GetFriendsRankedSongsWithNoUserRank(c *gin.Context) {
 }
 
 func (h *RankingsHandler) GetTopWeeklyTracks(c *gin.Context) {
-	songs, err := h.DAO.GetTopWeeklyRankedSongs(c.Request.Context())
+	songs, err := h.Service.GetTopWeeklyRankedSongs(c.Request.Context())
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve top weekly tracks"})
+		if err == sql.ErrNoRows {
+			c.JSON(http.StatusNotFound, gin.H{"error": "No tracks found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve top weekly tracks"})
+		}
 		return
 	}
 	c.JSON(http.StatusOK, songs)

--- a/internal/handler/rankings.go
+++ b/internal/handler/rankings.go
@@ -28,3 +28,12 @@ func (h *RankingsHandler) GetRankedSongs(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"rankings": rankings})
 }
+
+func (h *RankingsHandler) GetTopWeeklyTracks(c *gin.Context) {
+	songs, err := h.DAO.GetTopWeeklyRankedSongs(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to retrieve top weekly tracks"})
+		return
+	}
+	c.JSON(http.StatusOK, songs)
+}

--- a/internal/handler/spotify.go
+++ b/internal/handler/spotify.go
@@ -195,5 +195,4 @@ func (h *SpotifyHandler) GetRandomSongsByRandomGenreToRank(c *gin.Context) {
 		"genre": randomGenre,
 		"songs": songs,
 	})
-
 }

--- a/internal/route/api.go
+++ b/internal/route/api.go
@@ -27,9 +27,9 @@ func ApiRoutes(router *gin.RouterGroup, db *sql.DB) {
 		// spotify routes that need a access token
 		api.Use(middleware.SpotifyTokenMiddleware())
 		api.GET("/rank", spotifyHandler.GetSongsToRank)
-		api.GET("/random-songs/:limit", spotifyHandler.GetRandomSongsToRank)
-		api.GET("/random-songs-by-genre/:limit/:genre", spotifyHandler.GetRandomSongsByGenreToRank)
-		api.GET("/random-genre/:limit", spotifyHandler.GetRandomSongsByRandomGenreToRank)
+		api.GET("/random-songs/:limit", spotifyHandler.GetRandomSongsToRank) //Might delete later
+		api.GET("/:genre/:limit", spotifyHandler.GetRandomSongsByGenreToRank)
+		api.GET("/random-genre/:limit", spotifyHandler.GetRandomSongsByRandomGenreToRank) //Might delete later
 
 	}
 }

--- a/internal/route/friends.go
+++ b/internal/route/friends.go
@@ -16,6 +16,7 @@ func FriendRoutes(group *gin.RouterGroup, db *sql.DB) {
 	friends := group.Group("/friends")
 	{
 		friends.Use(middleware.AuthMiddleware())
+		friends.GET("/top-tracks", friendsHandler.GetTop5TracksAmongFriends)
 		// Routes to manage Friends
 		friends.GET("/:user_id", friendsHandler.GetFriends)
 		friends.DELETE("/:user_id/:friend_id", friendsHandler.DeleteFriendByID)

--- a/internal/route/rankings.go
+++ b/internal/route/rankings.go
@@ -22,5 +22,6 @@ func RankingsRoutes(group *gin.RouterGroup, db *sql.DB) {
 		rankings.GET("/ranked-songs", rankingsHandler.GetRankedSongs)
 		rankings.GET("/friends-ranked-songs", rankingsHandler.GetFriendsRankedSongs)
 		rankings.GET("/friends-songs", rankingsHandler.GetFriendsRankedSongsWithNoUserRank)
+		rankings.GET("/top-weekly", rankingsHandler.GetTopWeeklyTracks)
 	}
 }

--- a/internal/route/rankings.go
+++ b/internal/route/rankings.go
@@ -12,10 +12,11 @@ import (
 func RankingsRoutes(group *gin.RouterGroup, db *sql.DB) {
 	rankingsDAO := dao.NewRankingsDAO(db)
 	rankingsHandler := handler.NewRankingsHandler(rankingsDAO)
-	
+
 	rankings := group.Group("/rankings")
 	{
 		rankings.Use(middleware.AuthMiddleware())
 		rankings.GET("/:user_id", rankingsHandler.GetRankedSongs)
+		rankings.GET("/top-weekly", rankingsHandler.GetTopWeeklyTracks)
 	}
 }

--- a/internal/service/rankings.go
+++ b/internal/service/rankings.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/ranktify/ranktify-be/internal/dao"
+	"github.com/ranktify/ranktify-be/internal/model"
 )
 
 type RankingsService struct {
@@ -38,4 +40,13 @@ func (s *RankingsService) GetFriendsRankedSongsWithNoUserRank(userID uint64) (in
 		return http.StatusNotFound, content{"error": "Failed to retrieve rankings"}
 	}
 	return http.StatusOK, content{"User's friends songs": rankings}
+}
+
+// GetTopWeeklyRankedSongs
+func (s *RankingsService) GetTopWeeklyRankedSongs(ctx context.Context) ([]model.Song, error) {
+	songs, err := s.RankingsDAO.GetTopWeeklyRankedSongs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return songs, nil
 }

--- a/internal/service/rankings.go
+++ b/internal/service/rankings.go
@@ -42,7 +42,6 @@ func (s *RankingsService) GetFriendsRankedSongsWithNoUserRank(userID uint64) (in
 	return http.StatusOK, content{"User's friends songs": rankings}
 }
 
-// GetTopWeeklyRankedSongs
 func (s *RankingsService) GetTopWeeklyRankedSongs(ctx context.Context) ([]model.Song, error) {
 	songs, err := s.RankingsDAO.GetTopWeeklyRankedSongs(ctx)
 	if err != nil {


### PR DESCRIPTION
Need completed yet, will close #29. To top 5 among friends are in the `'ranktify/friends/top-tracks'` endpoint

Important to know that we can't access `spotify-owned` playlist like global top 50 due to changes in the api. 